### PR TITLE
fix: requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ hivemind-ggwave
 hivemind_bus_client>=0.1.0,<1.0.0
 HiveMind_presence>=0.0.2a3,<1.0.0
 ovos_utils>=0.0.33,<1.0.0
-ovos-bus-client>=0.0.6,<1.0.0
+ovos-bus-client>=0.0.6,<2.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-bus-client` package, allowing for a broader range of compatible versions up to, but not including, version 2.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->